### PR TITLE
Fix auto release spirit

### DIFF
--- a/DBM-PvP/PvPGeneral.lua
+++ b/DBM-PvP/PvPGeneral.lua
@@ -55,7 +55,7 @@ do
 
 	function mod:PLAYER_DEAD()
 		local _, instanceType = IsInInstance()
-		if instanceType == "pvp" and not C_DeathInfo.GetSelfResurrectOptions() and self.Options.AutoSpirit then
+		if instanceType == "pvp" and #C_DeathInfo.GetSelfResurrectOptions() == 0 and self.Options.AutoSpirit then
 			RepopMe()
 		end
 	end


### PR DESCRIPTION
`C_DeathInfo.GetSelfResurrectOptions()` always returns a table when dead, but we can check to see if it actually contains anything.

This will fix auto release.