### PR TITLE
classic ab: add code for reading the widget

### DIFF
--- a/DBM-PvP/PvPGeneral.lua
+++ b/DBM-PvP/PvPGeneral.lua
@@ -509,6 +509,15 @@ do
 				local info = C_UIWidgetManager.GetDoubleStatusBarWidgetVisualizationInfo(widgetID)
 				self:UpdateWinTimer(info.leftBarMax, info.leftBarValue, info.rightBarValue, allyBases, hordeBases)
 			end
+			if (widgetID == 1893 or widgetID == 1894) and DBM:AntiSpam(10, "PvPCABUpdate") then
+				local ally = mod:ExtractIconAndTextScore(1893)
+				local horde = mod:ExtractIconAndTextScore(1894)
+				DBM:Debug(tostring(widgetID)..
+					', ally: '..tostring(ally.bases)..':'..tostring(ally.score)..
+					', horde: '..tostring(horde.bases)..':'..tostring(horde.score), 2)
+				self:UpdateWinTimer(2000, ally.score, horde.score, ally.bases, horde.bases)
+			end
+
 		elseif widgetID == 1683 then -- TempleOfKotmogu
 			local widgetInfo = C_UIWidgetManager.GetDoubleStateIconRowVisualizationInfo(1683)
 			for _, v in pairs(widgetInfo.leftIcons) do
@@ -526,6 +535,27 @@ do
 		end
 	end
 	mod.UPDATE_UI_WIDGET = mod.AREA_POIS_UPDATED
+end
+
+function mod:ExtractIconAndTextScore(widgetID)
+	local info = C_UIWidgetManager.GetIconAndTextWidgetVisualizationInfo(widgetID)
+	local text = info.text
+	local score = 0;
+	for x in string.gmatch(text, '(%d+)/2000') do
+		score = tonumber(x)
+	end
+	local bases = score;
+	for x in string.gmatch(text, '(%d+)') do
+		local n = tonumber(x)
+		if n ~= 2000 and n ~= score then
+			bases = n
+		end
+	end
+	return {
+	  ['score'] = score,
+	  -- could get bases from areapois, which might be more reliable
+	  ['bases'] = bases,
+	}
 end
 
 --[[

--- a/DBM-PvP/PvPGeneral.lua
+++ b/DBM-PvP/PvPGeneral.lua
@@ -259,6 +259,11 @@ do
 		[5] = {1e-300, 2, 3, 4, 7, 10--[[Unknown]], 30--[[Unknown]]} -- Arathi/Deepwind
 	}
 
+	if isClassic then
+		-- 2014 values seem ok https://github.com/DeadlyBossMods/DBM-PvP/blob/843a882eae2276c2be0646287c37b114c51fcffb/DBM-PvP/Battlegrounds/Arathi.lua#L32-L39
+		resourcesPerSec[5] = {1e-300, 10/12, 10/9, 10/6, 10/3, 30}
+	end
+
 	function mod:UpdateWinTimer(maxScore, allianceScore, hordeScore, allianceBases, hordeBases)
 		local resPerSec = resourcesPerSec[numObjectives]
 		-- Start debug
@@ -509,7 +514,7 @@ do
 				local info = C_UIWidgetManager.GetDoubleStatusBarWidgetVisualizationInfo(widgetID)
 				self:UpdateWinTimer(info.leftBarMax, info.leftBarValue, info.rightBarValue, allyBases, hordeBases)
 			end
-			if (widgetID == 1893 or widgetID == 1894) and DBM:AntiSpam(10, "PvPCABUpdate") then
+			if widgetID == 1893 or widgetID == 1894 then
 				local ally = mod:ExtractIconAndTextScore(1893)
 				local horde = mod:ExtractIconAndTextScore(1894)
 				DBM:Debug(tostring(widgetID)..


### PR DESCRIPTION
@Developaws the resources are definitely off, maybe they should be halved, should check some 1.12 code
and `DBM:AntiSpam(10, "PvPCABUpdate")` could be removed, it just made the win timer less jumpy