### PR TITLE
Add Arathi final value

### DIFF
--- a/DBM-PvP/PvPGeneral.lua
+++ b/DBM-PvP/PvPGeneral.lua
@@ -373,9 +373,9 @@ do
 	local FACTION_HORDE, FACTION_ALLIANCE = FACTION_HORDE, FACTION_ALLIANCE
 	local winTimer = mod:NewTimer(30, "TimerWin", GetPlayerFactionGroup("player") == "Alliance" and "132486" or "132485") -- Interface\\Icons\\INV_BannerPVP_02.blp || Interface\\Icons\\INV_BannerPVP_01.blp
 	local resourcesPerSec = {
-		[3] = {1e-300, 1, 3, 4}, -- Gilneas
-		[4] = {1e-300, 2, 3, 4, 12--[[Data seems to suggest this, will need to confirm if win timers line up]]}, -- TempleOfKotmogu/EyeOfTheStorm
-		[5] = {1e-300, 2, 3, 4, 7, 1000--[[Unknown]]} -- Arathi/Deepwind
+		[3] = {1e-300, 0.5, 1.5, 2}, -- Gilneas
+		[4] = {1e-300, 1, 1.5, 2, 6}, -- TempleOfKotmogu/EyeOfTheStorm
+		[5] = {1e-300, 1, 1.5, 2, 3.5, 30--[[Unknown]]} -- Arathi/Deepwind
 	}
 
 	if isClassic then


### PR DESCRIPTION
Also fixed a major longstanding bug... We calculate in "resources per second", but blizzard awards them per tick (every 2 seconds). All the values had to be halved.

This may also make classic scores a little "more in line", and could possibly be removed in the future?