### PR TITLE
Improve Ashenvale mod a bit

### DIFF
--- a/DBM-PvP/localization.de.lua
+++ b/DBM-PvP/localization.de.lua
@@ -112,10 +112,13 @@ L:SetMiscLocalization({
 L = DBM:GetModLocalization("m1440")
 
 L:SetOptionLocalization({
-	EstimatedStartTimer = "Zeige Timer für geschätzte Startzeit des Events"
+	EstimatedStartTimer = "Zeige Timer für geschätzte Startzeit des Events",
+	HealthFrame         = "Zeige Infoframe mit Lebenspunkten der Bosses. Das Infoframe wird über deinen Raid und den Yell Chat synchronisiert. Aufgrund von API-Einschränkungen funktioniert diese Option nur zuverlässig wenn dein Raid über mehrere Bosse verteilt ist."
 })
 
 L:SetMiscLocalization({
-	TimerEstimate = "Event startet",
-	TimerSoon     = "Event startet gleich!",
+	TimerEstimate   = "Event startet",
+	TimerSoon       = "Event startet gleich!",
+	ErrorSuddenDrop = "Fortschritt für das Event ist plötzlich stark abgefallen, der Timer wird neu berechnet, dies kann ca. 2 bis 3 Minuten dauern.",
+	InfoMsgPrefix   = "DBM-PvP",
 })

--- a/DBM-PvP/localization.en.lua
+++ b/DBM-PvP/localization.en.lua
@@ -191,10 +191,13 @@ L:SetMiscLocalization({
 L = DBM:GetModLocalization("m1440")
 
 L:SetOptionLocalization({
-	EstimatedStartTimer = "Show timer for estimated event start time"
+	EstimatedStartTimer = "Show timer for estimated event start time",
+	HealthFrame         = "Show info frame with boss health, this works by syncing health across your raid and yell chat. This means this only works if someone with DBM-PvP in your raid is close to other bosses as yell chat has a low range/is unreliable."
 })
 
 L:SetMiscLocalization({
-	TimerEstimate = "Event starts",
-	TimerSoon     = "Event starts soon!",
+	TimerEstimate   = "Event starts",
+	TimerSoon       = "Event starts soon!",
+	ErrorSuddenDrop = "Detected sudden drop in event progress, re-calculating estimate, timer will update in 2-3 minutes.",
+	InfoMsgPrefix   = "DBM-PvP", -- Default for :AddMsg is the mod name which is just "Ashenvale" which doesn't look like a message from DBM
 })


### PR DESCRIPTION
* Sync across raid and yell chat as yell is pretty unreliable (range...)
* Add option to disable health info frame as it's often a bit useless
* Harden progress timer against more random fluctuations in the data