### PR TITLE
Fix LuaLS warnings

### DIFF
--- a/DBM-PvP/Battlegrounds/Alterac.lua
+++ b/DBM-PvP/Battlegrounds/Alterac.lua
@@ -14,7 +14,7 @@ mod:AddBoolOption("AutoTurnIn")
 do
 	local bgzone = false
 
-	local function Init(self)
+	function mod:Init()
 		local zoneID = DBM:GetCurrentArea()
 		if not bgzone and (zoneID == 30 or zoneID == 2197) then -- Regular AV (retail and classic), Korrak
 			bgzone = true
@@ -53,7 +53,7 @@ do
 	end
 
 	function mod:LOADING_SCREEN_DISABLED()
-		self:Schedule(1, Init, self)
+		self:ScheduleMethod(1, "Init")
 	end
 	mod.ZONE_CHANGED_NEW_AREA	= mod.LOADING_SCREEN_DISABLED
 	mod.PLAYER_ENTERING_WORLD	= mod.LOADING_SCREEN_DISABLED
@@ -103,7 +103,9 @@ do
 				end
 			end
 		elseif quest then
-			if GetItemCount(quest[1]) > quest[2] then
+			local questId = quest[1]
+			---@cast questId number
+			if GetItemCount(questId) > quest[2] then
 				SelectGossipAvailableQuest(1)
 			end
 		end

--- a/DBM-PvP/Battlegrounds/Ashran.lua
+++ b/DBM-PvP/Battlegrounds/Ashran.lua
@@ -16,14 +16,12 @@ mod:AddBoolOption("AutoTurnIn")
 do
 	local bgzone = false
 
-	local function Init(self)
+	function mod:Init()
 		local zoneID = DBM:GetCurrentArea()
 		if not bgzone and zoneID == 1191 then
 			bgzone = true
 			self:RegisterShortTermEvents(
-				"GOSSIP_SHOW",
-				"QUEST_PROGRESS",
-				"QUEST_COMPLETE"
+				"GOSSIP_SHOW"
 			)
 			if not self.tracker then
 				local generalMod = DBM:GetModByName("PvPGeneral")
@@ -35,7 +33,7 @@ do
 			end
 		elseif bgzone and zoneID ~= 1191 then
 			bgzone = false
-			self:UnregisterShormTermEvents()
+			self:UnregisterShortTermEvents()
 			if self.tracker then
 				self.tracker:Cancel()
 				self.tracker = nil
@@ -44,7 +42,7 @@ do
 	end
 
 	function mod:LOADING_SCREEN_DISABLED()
-		self:Schedule(1, Init, self)
+		self:ScheduleMethod(1, "Init")
 	end
 	mod.ZONE_CHANGED_NEW_AREA	= mod.LOADING_SCREEN_DISABLED
 	mod.PLAYER_ENTERING_WORLD	= mod.LOADING_SCREEN_DISABLED

--- a/DBM-PvP/Battlegrounds/SeethingShore.lua
+++ b/DBM-PvP/Battlegrounds/SeethingShore.lua
@@ -14,7 +14,7 @@ mod:RegisterEvents(
 do
 	local bgzone = false
 
-	local function Init(self)
+	function mod:Init()
 		local zoneID = DBM:GetCurrentArea()
 		if not bgzone and zoneID == 1803 then
 			bgzone = true
@@ -27,7 +27,7 @@ do
 	end
 
 	function mod:LOADING_SCREEN_DISABLED()
-		self:Schedule(1, Init, self)
+		self:ScheduleMethod(1, "Init")
 	end
 	mod.ZONE_CHANGED_NEW_AREA	= mod.LOADING_SCREEN_DISABLED
 	mod.PLAYER_ENTERING_WORLD	= mod.LOADING_SCREEN_DISABLED

--- a/DBM-PvP/Battlegrounds/SilvershardMines.lua
+++ b/DBM-PvP/Battlegrounds/SilvershardMines.lua
@@ -15,7 +15,7 @@ mod:RegisterEvents(
 do
 	local bgzone = false
 
-	local function Init(self)
+	function mod:Init()
 		local zoneID = DBM:GetCurrentArea()
 		if not bgzone and zoneID == 727 then
 			bgzone = true
@@ -34,7 +34,7 @@ do
 	end
 
 	function mod:LOADING_SCREEN_DISABLED()
-		self:Schedule(1, Init, self)
+		self:ScheduleMethod(1, "Init")
 	end
 	mod.ZONE_CHANGED_NEW_AREA	= mod.LOADING_SCREEN_DISABLED
 	mod.PLAYER_ENTERING_WORLD	= mod.LOADING_SCREEN_DISABLED

--- a/DBM-PvP/BloodMoon.lua
+++ b/DBM-PvP/BloodMoon.lua
@@ -13,8 +13,7 @@ mod:RegisterEvents(
 	"LOADING_SCREEN_DISABLED",
 	"ZONE_CHANGED_NEW_AREA",
 	"PLAYER_ENTERING_WORLD",
-	"UPDATE_UI_WIDGET",
-	"UNIT_AURA player"
+	"UPDATE_UI_WIDGET"
 )
 
 local startTimer = mod:NewNextTimer(0, 436097)

--- a/DBM-PvP/PvPGeneral.lua
+++ b/DBM-PvP/PvPGeneral.lua
@@ -657,7 +657,9 @@ do
 			end
 			if widgetID == 1671 or widgetID == 2074 then -- Standard battleground score predictor: 1671. Deepwind rework: 2074
 				local info = GetDoubleStatusBarWidgetVisualizationInfo(widgetID)
-				self:UpdateWinTimer(info.leftBarMax, info.leftBarValue, info.rightBarValue, allyBases, hordeBases)
+				if info then
+					self:UpdateWinTimer(info.leftBarMax, info.leftBarValue, info.rightBarValue, allyBases, hordeBases)
+				end
 			end
 			if widgetID == 1893 or widgetID == 1894 then -- Classic Arathi Basin
 				local totalScore = isWrath and 1600 or 2000
@@ -665,18 +667,22 @@ do
 			end
 		elseif widgetID == 1683 then -- Temple Of Kotmogu
 			local widgetInfo = GetDoubleStateIconRowVisualizationInfo(1683)
-			for _, v in pairs(widgetInfo.leftIcons) do
-				if v.iconState == 1 then
-					allyBases = allyBases + 1
+			if widgetInfo then
+				for _, v in pairs(widgetInfo.leftIcons) do
+					if v.iconState == 1 then
+						allyBases = allyBases + 1
+					end
 				end
-			end
-			for _, v in pairs(widgetInfo.rightIcons) do
-				if v.iconState == 1 then
-					hordeBases = hordeBases + 1
+				for _, v in pairs(widgetInfo.rightIcons) do
+					if v.iconState == 1 then
+						hordeBases = hordeBases + 1
+					end
 				end
 			end
 			local info = GetDoubleStatusBarWidgetVisualizationInfo(1689)
-			self:UpdateWinTimer(info.leftBarMax, info.leftBarValue, info.rightBarValue, allyBases, hordeBases)
+			if info then
+				self:UpdateWinTimer(info.leftBarMax, info.leftBarValue, info.rightBarValue, allyBases, hordeBases)
+			end
 		end
 	end
 	mod.UPDATE_UI_WIDGET = mod.AREA_POIS_UPDATED


### PR DESCRIPTION
This exposed a real bug: Ashran had a typo in UnregisterShortTermEvents, this wasn't detected before because LuaLS didn't know the type of the self parameter. This also means that the event checker couldn't know about the registered events which is why I changed it to be a method in the first place.