### PR TITLE
fix start timer for AV in classic era

### DIFF
--- a/DBM-PvP/PvPGeneral.lua
+++ b/DBM-PvP/PvPGeneral.lua
@@ -405,14 +405,15 @@ do
 	end
 
 	function mod:CHAT_MSG_BG_SYSTEM_NEUTRAL(msg)
-		if self.Options.TimerStart and msg:find(L.BgStart120) then
-			startTimer:Update(isClassic and 1.5 or 0, 120)
-		elseif self.Options.TimerStart and (msg:find(L.BgStart60) or msg == L.ArenaStart60 or msg:find(L.ArenaStart60)) then
-			startTimer:Update(isClassic and 61.5 or 60, 120)
-		elseif self.Options.TimerStart and (msg:find(L.BgStart30) or msg == L.ArenaStart30 or msg:find(L.ArenaStart30)) then
-			startTimer:Update(isClassic and 91.5 or 90, 120)
+		-- in Classic era the chat msg is about 1.5 seconds early
+		if self.Options.TimerStart and (msg:find(L.BgStart120) or msg:find(L.BgStart120era)) then
+			startTimer:Update(0, 120)
+		elseif self.Options.TimerStart and (msg:find(L.BgStart60) or msg:find(L.BgStart60era) or msg == L.ArenaStart60 or msg:find(L.ArenaStart60)) then
+			startTimer:Update(isClassic and 58.5 or 60, 120)
+		elseif self.Options.TimerStart and (msg:find(L.BgStart30) or msg:find(L.BgStart30era) or msg == L.ArenaStart30 or msg:find(L.ArenaStart30)) then
+			startTimer:Update(isClassic and 88.5 or 90, 120)
 		elseif self.Options.TimerStart and (msg == L.ArenaStart15 or msg:find(L.ArenaStart15)) then
-			startTimer:Update(isClassic and 106.5 or 105, 120)
+			startTimer:Update(isClassic and 103.5 or 105, 120)
 		elseif not isClassic and (msg == L.Vulnerable1 or msg == L.Vulnerable2 or msg:find(L.Vulnerable1) or msg:find(L.Vulnerable2)) then
 			vulnerableTimer:Start()
 		end

--- a/DBM-PvP/localization.en.lua
+++ b/DBM-PvP/localization.en.lua
@@ -36,6 +36,10 @@ L:SetMiscLocalization({
 	BgStart120          = "The [bB]attle.*begin.*in 2 minutes.",
 	BgStart60           = "The [bB]attle.*begin.*in 1 minute.",
 	BgStart30           = "The [bB]attle.*begin.*in 30 seconds.",
+	-- Classic Era: 2 minutes until the battle for Alterac Valley begins.
+	BgStart120era       = "2 minutes until the [bB]attle.*begins.",
+	BgStart60era        = "1 minute until the [bB]attle.*begins.",
+	BgStart30era        = "30 seconds until the [bB]attle.*begins.",
 	ArenaStart60		= "One minute until the Arena battle begins!",
 	ArenaStart30		= "Thirty seconds until the Arena battle begins!",
 	ArenaStart15		= "Fifteen seconds until the Arena battle begins!",


### PR DESCRIPTION
I noticed that the starttime timer was never triggered for Alterac Valley in Classic era.
After I made it work with a new matching on the chat message, I noticed the timing was off for a fewseconds. I think, the 1.5 seconds adjustment that already existed was done incorrect because it seems the message is 1.5 seconds early.

Anyway with these changes it now works in Alterac Valley on classic era.

Let me know what you think.