### PR TITLE
fix: adjust AV timers for cataclysm

### DIFF
--- a/DBM-PvP/PvPGeneral.lua
+++ b/DBM-PvP/PvPGeneral.lua
@@ -523,7 +523,7 @@ do
 		-- retail av
 		[91]    = 243,
 		-- classic av
-		[1459]  = (isBCC or isWrath) and 243 or 304,
+		[1459]  = isClassic and 304 or 243,
 		-- korrak
 		[1537]  = 243
 	}


### PR DESCRIPTION
AV timers in cataclysm are 4 minutes